### PR TITLE
Strip whitespace around input line parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## [Unreleased]
 
+
+## [1.2.0] - 2020-11-22
+
 ### Added
 - Stripping of edge whitespace in line parts in `input`.
 
@@ -49,6 +52,7 @@
 - Initial implementation
 
 
-[Unreleased]: https://github.com/nkantar/sus/compare/1.1.0...HEAD
+[Unreleased]: https://github.com/nkantar/sus/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/nkantar/sus/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/nkantar/sus/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/nkantar/sus/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!--
 - Added: for new features
-- Changed for changes in existing functionality
+- Changed: for changes in existing functionality
 - Deprecated: for soon-to-be removed features
 - Removed: for now removed features
 - Fixed: for any bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## [Unreleased]
 
+### Added
+- Stripping of edge whitespace in line parts in `input`.
+
 
 ## [1.1.0] - 2020-09-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sus"
-version = "1.1.0"
+version = "1.2.0"
 description = "Really simple static website URL shortener"
 license = "MIT"
 authors = ["Nik Kantar <nik@nkantar.com>"]

--- a/src/sus.py
+++ b/src/sus.py
@@ -48,7 +48,8 @@ def _sanitize_url(url: str) -> str:
 
 
 def _generate_page_params(line: str) -> Tuple[str, str]:
-    slug, url = line.split(SPLIT_CHAR, 1)
+    # strip edge whitespace while splitting
+    slug, url = [line_part.strip() for line_part in line.split(SPLIT_CHAR, 1)]
     html = HTML.substitute(url=_sanitize_url(url))
     return slug, html
 

--- a/tests/test_generate_page_params.py
+++ b/tests/test_generate_page_params.py
@@ -31,3 +31,13 @@ def test_generate_page_params_quote():
         html
         == "<meta http-equiv='refresh' content='0;url=https://example.com/foo%27bar' />"
     )
+
+
+def test_generate_page_params_whitespace():
+    line = "\tfoo  |\nhttps://example.com/foo "
+    slug, html = _generate_page_params(line)
+
+    assert slug == "foo"
+    assert (
+        html == "<meta http-equiv='refresh' content='0;url=https://example.com/foo' />"
+    )


### PR DESCRIPTION
This allows input to be more comfortably spaced out for legibility, like this:
    
```
foo | https://example.com/foo
bar | https://example.com/bar
```

instead of having to be squished, like this:

```
foo|https://example.com/foo
bar|https://example.com/bar
```